### PR TITLE
chore: remove unused nanoid import

### DIFF
--- a/src/components/AddClassDialog.tsx
+++ b/src/components/AddClassDialog.tsx
@@ -14,7 +14,6 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Plus } from "lucide-react";
-import { nanoid } from "nanoid";
 
 export default function AddClassDialog() {
   const router = useRouter();                               // 🚀 para refresh rápido


### PR DESCRIPTION
## Summary
- remove unused `nanoid` import from AddClassDialog

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897a3cc4e648322b3474dfd84156081