### PR TITLE
Use Next.js router refresh after mutations

### DIFF
--- a/src/app/answer-keys/AddAnswerKeyDialog.tsx
+++ b/src/app/answer-keys/AddAnswerKeyDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabaseClient";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -8,6 +9,7 @@ import { buildHtml } from "@/lib/buildHtml";
 
 
 export default function AddAnswerKeyDialog() {
+  const router = useRouter();
   const [open, setOpen] = useState(false);
   const [classes, setClasses] = useState<{ id: string; name: string }[]>([]);
 
@@ -83,7 +85,7 @@ export default function AddAnswerKeyDialog() {
     }
 
     setOpen(false);
-    window.location.reload();
+    router.refresh();
   }
 
   /* ────────────────────────── JSX ──────────────────────────────── */

--- a/src/components/AddStudentDialog.tsx
+++ b/src/components/AddStudentDialog.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { useRouter } from "next/navigation"
 import { supabase } from "@/lib/supabaseClient"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
@@ -13,6 +14,7 @@ type Props = {
 }
 
 export default function AddStudentDialog({ classId }: Props) {
+  const router = useRouter()
   const [open, setOpen] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState("")
@@ -73,7 +75,7 @@ export default function AddStudentDialog({ classId }: Props) {
     if (dbErr) setError(dbErr.message)
     else {
       setOpen(false)
-      location.reload()        // mostra o novo aluno
+      router.refresh()        // mostra o novo aluno
     }
     setSaving(false)
   }

--- a/src/components/ClassActions.tsx
+++ b/src/components/ClassActions.tsx
@@ -1,12 +1,14 @@
 "use client"
 
-import { Edit, Trash } from "lucide-react"
+import { Trash } from "lucide-react"
 import { supabase } from "@/lib/supabaseClient"
 import EditClassDialog from "@/components/EditClassDialog"
+import { useRouter } from "next/navigation"
 
 type Props = { id: string; name: string; year: number }
 
 export default function ClassActions(cls: Props) {
+  const router = useRouter()
   return (
     <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
       <EditClassDialog cls={cls} />
@@ -17,7 +19,7 @@ export default function ClassActions(cls: Props) {
         onClick={async () => {
           if (!confirm(`Excluir a turma ${cls.name}?`)) return
           await supabase.from("classes").delete().eq("id", cls.id)
-          location.reload()
+          router.refresh()
         }}
       >
         <Trash size={16}/>

--- a/src/components/EditClassDialog.tsx
+++ b/src/components/EditClassDialog.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { useRouter } from "next/navigation"
 import { supabase } from "@/lib/supabaseClient"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
@@ -11,6 +12,7 @@ import { Edit } from "lucide-react"
 type Props = { cls: { id: string; name: string; year: number } }
 
 export default function EditClassDialog({ cls }: Props) {
+  const router = useRouter()
   const [open, setOpen] = useState(false)
   const [saving, setSaving] = useState(false)
   const [form, setForm] = useState({ name: cls.name, year: cls.year })
@@ -27,7 +29,7 @@ export default function EditClassDialog({ cls }: Props) {
 
     if (!error) {
       setOpen(false)
-      location.reload()
+      router.refresh()
     }
     setSaving(false)
   }

--- a/src/components/EditStudentDialog.tsx
+++ b/src/components/EditStudentDialog.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { useRouter } from "next/navigation"
 import { supabase } from "@/lib/supabaseClient"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
@@ -17,6 +18,7 @@ type Student = {
 }
 
 export default function EditStudentDialog({ student }: { student: Student }) {
+  const router = useRouter()
   const [open, setOpen] = useState(false)
   const [saving, setSaving] = useState(false)
   const [form, setForm] = useState<Student>(student)
@@ -39,7 +41,7 @@ export default function EditStudentDialog({ student }: { student: Student }) {
 
     if (!error) {
       setOpen(false)
-      location.reload()
+      router.refresh()
     } else {
       alert("Erro ao salvar: " + error.message)
     }

--- a/src/components/StudentActions.tsx
+++ b/src/components/StudentActions.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { Edit, Trash } from "lucide-react"
+import { Trash } from "lucide-react"
 import { supabase } from "@/lib/supabaseClient"
 import EditStudentDialog from "@/components/EditStudentDialog"
+import { useRouter } from "next/navigation"
 
 type Props = {
   id: string
@@ -13,6 +14,7 @@ type Props = {
 }
 
 export default function StudentActions(student: Props) {
+  const router = useRouter()
   return (
     <div className="flex gap-2">
       {/* botão editar */}
@@ -23,7 +25,7 @@ export default function StudentActions(student: Props) {
         onClick={async () => {
           if (!confirm(`Excluir ${student.name}?`)) return
           await supabase.from("students").delete().eq("id", student.id)
-          location.reload()
+          router.refresh()
         }}
         title="Excluir"
         className="text-red-600 hover:text-red-800"


### PR DESCRIPTION
## Summary
- Replace `location.reload` calls with Next.js `router.refresh()` in dialogs and action components
- Import `useRouter` and invoke `router.refresh()` after successful create, update, and delete operations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897a3cdd6bc8322ba2e52afb75d0bfb