### PR TITLE
Display points per question in answer sheet HTML

### DIFF
--- a/src/lib/buildHtml.ts
+++ b/src/lib/buildHtml.ts
@@ -8,12 +8,14 @@ export function buildHtml({
   headerInstructions,
   numQuestions,
   questionsPerRow,
+  pointsPerQuestion = 1,
   classIds = [],
 }: {
   headerTitle: string;
   headerInstructions: string;
   numQuestions: number;
   questionsPerRow: number;
+  pointsPerQuestion?: number;
   classIds?: string[];
 }) {
   // Build Turma rows
@@ -85,6 +87,7 @@ export function buildHtml({
   <div class="box"><h1>${headerTitle}</h1></div>
   <div class="box">Nome do Aluno: _______________________________________________</div>
   <div class="box">${headerInstructions.replace(/\n/g, "<br/>")}</div>
+  <div class="box"><strong>Pontuação por questão:</strong> ${pointsPerQuestion}</div>
 
   <div class="box">
     <strong>Turmas:</strong>


### PR DESCRIPTION
## Summary
- include `pointsPerQuestion` param in `buildHtml` and render score per question in generated sheet

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6897a3cfac808322aaee16e30aad9988