### PR TITLE
Remove duplicate title paragraph in answer keys

### DIFF
--- a/src/app/answer-keys/page.tsx
+++ b/src/app/answer-keys/page.tsx
@@ -45,8 +45,6 @@ export default async function AnswerKeysPage() {
               <div>
                 <p className="font-medium">{key.title}</p>
 
-                <p className="font-medium mb-1">{key.title}</p>
-
                 {key.sheet_url && (
                   <a
                     href={key.sheet_url}


### PR DESCRIPTION
## Summary
- show answer key title only once per list item

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897a3d2188c8322a30a7b7ff53518d7