### PR TITLE
feat: add animated next steps page

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,12 @@
 
 5. **Documentação Atualizada**  
    - Este README deve ser atualizado com este resumo de próximos passos, instruções de configuração e guia de uso das novas funcionalidades.
+
+## 6. Roadmap Visual
+
+Uma página animada de "Next Steps" foi adicionada para apresentar os próximos objetivos do projeto de maneira clara e elegante.
+
+1. Execute `npm run dev`.
+2. Acesse [http://localhost:3000/next-steps](http://localhost:3000/next-steps) para visualizar o roteiro.
+
+Essa página utiliza [Framer Motion](https://www.framer.com/motion/) para efeitos de transição suaves.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@supabase/supabase-js": "^2.53.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.23.12",
         "lucide-react": "^0.534.0",
         "nanoid": "^5.1.5",
         "next": "15.4.5",
@@ -4978,6 +4979,33 @@
         "shallowequal": "^1.1.0"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -6476,6 +6504,21 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@supabase/supabase-js": "^2.53.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.23.12",
     "lucide-react": "^0.534.0",
     "nanoid": "^5.1.5",
     "next": "15.4.5",

--- a/src/app/next-steps/page.tsx
+++ b/src/app/next-steps/page.tsx
@@ -1,0 +1,51 @@
+import { motion } from "framer-motion";
+
+interface Step {
+  title: string;
+  description: string;
+}
+
+const steps: Step[] = [
+  {
+    title: "Design exam templates",
+    description: "Create templates for exams with dynamic placeholders.",
+  },
+  {
+    title: "Integrate analytics",
+    description: "Visualize students’ performance across exams.",
+  },
+  {
+    title: "Collaborative editing",
+    description: "Allow multiple instructors to edit exam content in real-time.",
+  },
+];
+
+export default function NextStepsPage() {
+  return (
+    <div className="max-w-2xl mx-auto p-8 space-y-6">
+      <motion.h1
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+        className="text-3xl font-bold text-center"
+      >
+        Next Steps
+      </motion.h1>
+      <ul className="space-y-4">
+        {steps.map((step, index) => (
+          <motion.li
+            key={step.title}
+            initial={{ opacity: 0, x: -20 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ delay: index * 0.1 }}
+            className="p-4 rounded-md border bg-white shadow-sm"
+          >
+            <h2 className="text-xl font-semibold">{step.title}</h2>
+            <p className="text-gray-600">{step.description}</p>
+          </motion.li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 
 export default function Home() {
   return (
@@ -49,6 +50,12 @@ export default function Home() {
           >
             Read our docs
           </a>
+          <Link
+            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto"
+            href="/next-steps"
+          >
+            Next steps
+          </Link>
         </div>
       </main>
       <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">


### PR DESCRIPTION
## Summary
- install framer-motion for simple page animations
- add `/next-steps` page showing animated project roadmap
- link home page to the new route and document in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897a5ec75a48322aa1430bc80b8793b